### PR TITLE
Remap ports to firmware 2.0.00.0017

### DIFF
--- a/movehub.js
+++ b/movehub.js
@@ -90,12 +90,12 @@ class Hub extends EventEmitter {
             40: 'TILT'
         };
         this.port2num = {
-            C: 0x01,
-            D: 0x02,
+            A: 0x00,
+            B: 0x01,
+            C: 0x02,
+            D: 0x03,
+            AB: 0x10,
             LED: 0x32,
-            A: 0x37,
-            B: 0x38,
-            AB: 0x39,
             TILT: 0x3A
         };
         this.num2port = {};
@@ -340,7 +340,7 @@ class Hub extends EventEmitter {
      * @param {function} callback
      */
     motorTimeMulti(seconds, dutyCycleA, dutyCycleB, callback) {
-        this.write(this.encodeMotorTimeMulti(0x39, seconds, dutyCycleA, dutyCycleB), callback);
+        this.write(this.encodeMotorTimeMulti(this.port2num['AB'], seconds, dutyCycleA, dutyCycleB), callback);
     }
 
     /**
@@ -372,7 +372,7 @@ class Hub extends EventEmitter {
      * @param {function} callback
      */
     motorAngleMulti(angle, dutyCycleA, dutyCycleB, callback) {
-        this.write(this.encodeMotorAngleMulti(0x39, angle, dutyCycleA, dutyCycleB), callback);
+        this.write(this.encodeMotorAngleMulti(this.port2num['AB'], angle, dutyCycleA, dutyCycleB), callback);
     }
 
     /**


### PR DESCRIPTION
Remapped ports to match numbers from firmware 2.0.00.0017.

Would be good if package would request firmware version and based on that would decide port numbers. But I think it is unnecessary as most will always update firmware to the newest version.

Haven't tested this change (BLE adapter problems), but made similar change to this repository and it works. It is a Web Bluetooth API port of this library https://github.com/ttu/lego-boost-browser/commit/eedddd8c42937d3f2f6e760cb9a30e05967ab6a1

Pretty likely this is a related issue: https://github.com/hobbyquaker/node-movehub/issues/3